### PR TITLE
Add instructions and fix schemas for c9 use

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ Next:
   * The server will be running on http://{docker-ip}:3000
 
 
+# Cloud 9
+
+Alternatively, you can use Cloud 9 (https://c9.io) to setup a cloud-based containerised environment. 
+
+ * Setup a new workspace based on the 'Blank' image, cloning from this repo
+ * Setup mongodb based on the Cloud 9 instructions: https://community.c9.io/t/setting-up-mongodb/1717
+ * Follow the Setup instructions for the Mngo, PHP, Python, Node, Ruby and Perl instructions as usual.

--- a/static/index.html
+++ b/static/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 
 
-<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
-<script src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+<script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
 
 


### PR DESCRIPTION
Removing the schema (`s/http:\//g`) on the JavaScript import lines removes the Mixed Content issues that was preventing the assets from loading in the cloud9 environment. This change should not effect local/docker setups. 